### PR TITLE
Fix language parsing from GetSeries.php results.

### DIFF
--- a/src/Moinax/TvDb/Serie.php
+++ b/src/Moinax/TvDb/Serie.php
@@ -136,6 +136,9 @@ class Serie
     {
         $this->id = (int)$data->id;
         $this->language = (string)$data->Language;
+        if(isset($data->language)) {
+            $this->language = (string)$data->language;
+        }
         $this->name = (string)$data->SeriesName;
         $this->banner = (string)$data->banner;
         $this->overview = (string)$data->Overview;


### PR DESCRIPTION
The language field name from GetSeries.php differs of the one in Base Series Record (language vs Language).
