### PR TITLE
Add: Support for AliasNames

### DIFF
--- a/src/Moinax/TvDb/Serie.php
+++ b/src/Moinax/TvDb/Serie.php
@@ -166,7 +166,7 @@ class Serie
         $this->poster = (string)$data->poster;
         $this->zap2ItId = (string)$data->zap2it_id;
         if(isset($data->AliasNames)) {
-                $this->aliasNames = (array)Client::removeEmptyIndexes(explode('|', (string)$data->AliasNames));
+            $this->aliasNames = (array)Client::removeEmptyIndexes(explode('|', (string)$data->AliasNames));
         }
     }
 }


### PR DESCRIPTION
TvDB's GetSeries function can return AliasNames. Example: http://thetvdb.com/api/GetSeries.php?seriesname=Raumschiff%20Enterprise%20-%20Das%20n%C3%A4chste%20Jahrhundert&language=de
