### PR TITLE
Implement JsonSerializable

### DIFF
--- a/examples/index.php
+++ b/examples/index.php
@@ -20,6 +20,11 @@ $data = $tvdb->getSeries('Walking Dead');
 $episode = $tvdb->getEpisode($data[0]->id, 1, 1, 'en');
 var_dump($episode);
 
+// format the episode as JSON
+$tvdb->setJsonDateFormat(TVDB_JSON_DATE_FORMAT);
+$tvdb->setJsonTimeFormat(TVDB_JSON_TIME_FORMAT);
+var_dump(json_encode($episode));
+
 /*$date = new \DateTime('-1 day');
 $data = $tvdb->getUpdates($date->getTimestamp());
 var_dump($data);

--- a/examples/settings.php.dist
+++ b/examples/settings.php.dist
@@ -5,3 +5,5 @@
  */
 define('TVDB_URL', 'http://thetvdb.com');
 define('TVDB_API_KEY', '');
+define('TVDB_JSON_DATE_FORMAT', 'd-m-Y');
+define('TVDB_JSON_TIME_FORMAT', 'H:i:s');

--- a/src/Moinax/TvDb/Actor.php
+++ b/src/Moinax/TvDb/Actor.php
@@ -9,7 +9,7 @@ namespace Moinax\TvDb;
  * @author Lucas Personnaz <lucas.personnaz@gmail.com>
  **/
 
-class Actor 
+class Actor implements \JsonSerializable
 {
 
 	/**
@@ -53,4 +53,14 @@ class Actor
 		$this->sortOrder = (int)$data->SortOrder;
 	}
 
+	public function jsonSerialize()
+	{
+		return [
+			'id'        => $this->id,
+			'image'     => $this->image,
+			'name'      => $this->name,
+			'role'      => $this->role,
+			'sortOrder' => $this->sortOrder,
+		];
+	}
 }

--- a/src/Moinax/TvDb/Banner.php
+++ b/src/Moinax/TvDb/Banner.php
@@ -8,7 +8,7 @@ namespace Moinax\TvDb;
  * @package TvDb
  * @author Jérôme Poskin <moinax@gmail.com>
  */
-class Banner
+class Banner implements \JsonSerializable
 {
 
     /**
@@ -92,5 +92,23 @@ class Banner
         $this->thumbnailPath = (string)$data->ThumbnailPath;
         $this->vignettePath = (string)$data->VignettePath;
         $this->season = (int)$data->Season;
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+          'id' => $this->id,
+          'path' => $this->path,
+          'type' => $this->type,
+          'type2' => $this->type2,
+          'colors' => $this->colors,
+          'language' => $this->language,
+          'rating' => $this->rating,
+          'ratingCount' => $this->ratingCount,
+          'seriesName' => $this->seriesName,
+          'thumbnailPath' => $this->thumbnailPath,
+          'vignettePath' => $this->vignettePath,
+          'season' => $this->season,
+        ];
     }
 }

--- a/src/Moinax/TvDb/Client.php
+++ b/src/Moinax/TvDb/Client.php
@@ -69,6 +69,19 @@ class Client
     protected $httpClient;
 
     /**
+     * Date format used for casting objects to JSON
+     *
+     * @var string
+     */
+    public static $JSON_DATE_FORMAT = 'Y-m-d';
+
+    /**
+     * Time format used for casting objects to JSON
+     * @var string
+     */
+    public static $JSON_TIME_FORMAT = 'H:i:s';
+
+    /**
      * @param string $baseUrl Domain name of the api without trailing slash
      * @param string $apiKey Api key provided by http://thetvdb.com
      */
@@ -318,7 +331,6 @@ class Client
         return array('series' => $series, 'episodes' => $episodes);
     }
 
-
     /**
      * Fetch banner raw jpeg data from banner mirror.
      *
@@ -331,7 +343,27 @@ class Client
         return $this->httpClient->fetch($url, array(), self::GET);
     }
 
+    /**
+     * Set the default date format used for casting objects to JSON
+     *
+     * @param string $defaultDateFormat
+     */
+    public static function setJsonDateFormat($defaultDateFormat)
+    {
+        static::$JSON_DATE_FORMAT = $defaultDateFormat;
+    }
 
+    /**
+     * Set the default time format used for casting objects to JSON
+     *
+     * @param string $defaultTimeFormat
+     */
+    public static function setJsonTimeFormat($defaultTimeFormat)
+    {
+        static::$JSON_TIME_FORMAT = $defaultTimeFormat;
+    }
+
+    
     /**
      * Fetches data via curl and returns result
      *

--- a/src/Moinax/TvDb/Episode.php
+++ b/src/Moinax/TvDb/Episode.php
@@ -8,7 +8,7 @@ namespace Moinax\TvDb;
  * @package TvDb
  * @author Jérôme Poskin <moinax@gmail.com>
  **/
-class Episode
+class Episode implements \JsonSerializable
 {
 
     /**
@@ -122,5 +122,36 @@ class Episode
         $this->thumbnail = (string)$data->filename;
         $this->seasonId = (int)$data->seasonid;
         $this->serieId = (int)$data->seriesid;
+    }
+
+    public function jsonSerialize()
+    {
+        $dateFormat = Client::$JSON_DATE_FORMAT;
+        $hourFormat = Client::$JSON_TIME_FORMAT;
+
+        $array = [
+          'id' => $this->id,
+          'number' => $this->number,
+          'season' => $this->season,
+          'directors' => $this->directors,
+          'name' => $this->name,
+          'firstAired' => $this->firstAired,
+          'guestStars' => $this->guestStars,
+          'imdbId' => $this->imdbId,
+          'language' => $this->language,
+          'overview' => $this->overview,
+          'rating' => $this->rating,
+          'ratingCount' => $this->ratingCount,
+          'lastUpdated' => $this->lastUpdated->format($dateFormat . ' ' . $hourFormat),
+          'writers' => $this->writers,
+          'thumbnail' => $this->thumbnail,
+          'seasonId' => $this->seasonId,
+          'serieId' => $this->serieId,
+        ];
+
+        if($array['firstAired'])
+            $array['firstAired'] = $array['firstAired']->format($dateFormat);
+
+        return $array;
     }
 }

--- a/src/Moinax/TvDb/Serie.php
+++ b/src/Moinax/TvDb/Serie.php
@@ -8,7 +8,7 @@ namespace Moinax\TvDb;
  * @package TvDb
  * @author Jérôme Poskin <moinax@gmail.com>
  */
-class Serie
+class Serie implements \JsonSerializable
 {
     /**
      * @var int
@@ -168,5 +168,38 @@ class Serie
         if(isset($data->AliasNames)) {
             $this->aliasNames = (array)Client::removeEmptyIndexes(explode('|', (string)$data->AliasNames));
         }
+    }
+
+    public function jsonSerialize()
+    {
+        $dateFormat = Client::$JSON_DATE_FORMAT;
+        $hourFormat = Client::$JSON_TIME_FORMAT;
+
+        return [
+          'id' => $this->id,
+          'language' => $this->language,
+          'name' => $this->name,
+          'banner' => $this->banner,
+          'overview' => $this->overview,
+          'firstAired' => $this->firstAired->format($dateFormat),
+          'imdbId' => $this->imdbId,
+          'actors' => $this->actors,
+          'airsDayOfWeek' => $this->airsDayOfWeek,
+          'airsTime' => $this->airsTime,
+          'contentRating' => $this->contentRating,
+          'genres' => $this->genres,
+          'network' => $this->network,
+          'rating' => $this->rating,
+          'ratingCount' => $this->ratingCount,
+          'runtime' => $this->runtime,
+          'status' => $this->status,
+          'added' => $this->added->format($dateFormat . ' '. $hourFormat),
+          'addedBy' => $this->addedBy,
+          'fanArt' => $this->fanArt,
+          'lastUpdated' => $this->lastUpdated->format($dateFormat . ' '. $hourFormat),
+          'poster' => $this->poster,
+          'zap2ItId' => $this->zap2ItId,
+          'aliasNames' => $this->aliasNames,
+        ];
     }
 }


### PR DESCRIPTION
Being able to cast your objects with json_encode is a _great_ help when building an API.
The default date- and timeformat is defined in Client.php

In combination with this (merged) PR in https://github.com/laravel/framework/pull/11434 it's possible to do

```php
// controller.php
public function getById($serieId)
{
    return $this->tvdb->getSerie($serieId);
}
```

And a valid JSON response would be sent to the browser.

This proposal is fully backwards compatible.