### PR TITLE
Fixing HTTPS and exception on no results

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Usage:
 use Moinax\TvDb\Client;
 $apiKey = 'YOURAPIKEY';
 
-$tvdb = new Client("http://thetvdb.com", $apiKey);
+$tvdb = new Client("https://thetvdb.com", $apiKey);
 $tvdb->getSerie(75710);
 ```
 
@@ -42,7 +42,7 @@ $apiKey = 'YOURAPIKEY';
 $cache = new FilesystemCache(__DIR__ . '/cache');
 $httpClient = new CacheClient($cache, $ttl);
 
-$tvdb = new Client("http://thetvdb.com", $apiKey);
+$tvdb = new Client("https://thetvdb.com", $apiKey);
 $tvdb->setHttpClient($httpClient);
 
 $tvdb->getSerie(75710); //This request will fetch the resource online.

--- a/examples/settings.php.dist
+++ b/examples/settings.php.dist
@@ -3,5 +3,5 @@
  * Constants defined here outside of class because class constants can't be
  * the result of any operation (concatenation)
  */
-define('TVDB_URL', 'http://thetvdb.com');
+define('TVDB_URL', 'https://thetvdb.com');
 define('TVDB_API_KEY', '');

--- a/src/Moinax/TvDb/Client.php
+++ b/src/Moinax/TvDb/Client.php
@@ -445,7 +445,7 @@ class Client
         }
 
         $simpleXml = simplexml_load_string($data);
-        if (!$simpleXml) {
+        if ($simpleXml === FALSE) {
             if (extension_loaded('libxml')) {
                 $xmlErrors = libxml_get_errors();
                 $errors = array();

--- a/src/Moinax/TvDb/Client.php
+++ b/src/Moinax/TvDb/Client.php
@@ -500,7 +500,7 @@ class Client
         if (empty($this->mirrors)) {
             $this->getMirrors();
         }
-        return $this->mirrors[$typeMask][array_rand($this->mirrors[$typeMask], 1)];
+        return $this->baseUrl;
 
     }
 


### PR DESCRIPTION
The TvDb api changed to https only. Requests to http endpoints fail. Using https fixes that. Unfortunately, the mirrors.xml file still gives http links. A quick workaround is to use the provided base url and disregard any mirrors (which are not provided in the mirrors.xml file anyway).

There was a bug where if no results were found for a certain request, the parsed xml response evaluated as false and triggered an exeption despite being valid. A stricter false check corrects this.